### PR TITLE
PluginSystem: Rework how commands receive author IDs, do their owner checks and provide default behavior

### DIFF
--- a/src/bot/bot.js
+++ b/src/bot/bot.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 19:05:34
+ * Last Modified: 08.07.2023 00:41:25
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -195,7 +195,7 @@ Bot.prototype.handleMissingGameLicenses = function() {};
 /**
  * Our commandHandler respondModule implementation - Sends a message to a Steam user
  * @param {object} _this The Bot object context
- * @param {object} resInfo Object containing information passed to command by friendMessage event
+ * @param {import("../commands/commandHandler.js").resInfo} resInfo Object containing information passed to command by friendMessage event
  * @param {string} txt The text to send
  * @param {boolean} retry Internal: true if this message called itself again to send failure message
  * @param {number} part Internal: Index of which part to send for messages larger than 750 chars

--- a/src/bot/events/friendMessage.js
+++ b/src/bot/events/friendMessage.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 09:33:05
+ * Last Modified: 10.07.2023 09:36:42
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -30,7 +30,7 @@ Bot.prototype._attachSteamFriendMessageEvent = function() {
         let steamID = msg.steamid_friend;
 
         let steamID64 = new SteamID(String(steamID)).getSteamID64();
-        let resInfo   = { userID: steamID64, cmdprefix: "!" }; // Object required for sendChatMessage(), our commandHandler respondModule implementation
+        let resInfo   = { userID: steamID64, cmdprefix: "!", fromSteamChat: true }; // Object required for sendChatMessage(), our commandHandler respondModule implementation
 
         // Check if another friendMessage handler is currently active
         if (this.friendMessageBlock.includes(steamID64)) return logger("debug", `[${this.logPrefix}] Ignoring friendMessage event from ${steamID64} as user is on friendMessageBlock list.`);

--- a/src/bot/events/friendMessage.js
+++ b/src/bot/events/friendMessage.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 29.06.2023 22:35:03
+ * Last Modified: 10.07.2023 09:33:05
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -30,7 +30,7 @@ Bot.prototype._attachSteamFriendMessageEvent = function() {
         let steamID = msg.steamid_friend;
 
         let steamID64 = new SteamID(String(steamID)).getSteamID64();
-        let resInfo   = { steamID64: steamID64, cmdprefix: "!" }; // Object required for sendChatMessage(), our commandHandler respondModule implementation
+        let resInfo   = { userID: steamID64, cmdprefix: "!" }; // Object required for sendChatMessage(), our commandHandler respondModule implementation
 
         // Check if another friendMessage handler is currently active
         if (this.friendMessageBlock.includes(steamID64)) return logger("debug", `[${this.logPrefix}] Ignoring friendMessage event from ${steamID64} as user is on friendMessageBlock list.`);
@@ -90,7 +90,7 @@ Bot.prototype._attachSteamFriendMessageEvent = function() {
         let cont = message.slice(1).split(" "); // Remove prefix and split
         let args = cont.slice(1);               // Remove cmd name to only get arguments
 
-        let success = this.controller.commandHandler.runCommand(cont[0].toLowerCase(), args, steamID64, this.sendChatMessage, this, resInfo);
+        let success = this.controller.commandHandler.runCommand(cont[0].toLowerCase(), args, this.sendChatMessage, this, resInfo);
 
         if (!success) this.sendChatMessage(this, resInfo, this.controller.data.lang.commandnotfound.replace(/cmdprefix/g, resInfo.cmdprefix)); // Send cmd not found msg if runCommand() returned false
     });

--- a/src/bot/events/relationship.js
+++ b/src/bot/events/relationship.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 29.06.2023 22:35:03
+ * Last Modified: 10.07.2023 09:33:09
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -39,7 +39,7 @@ Bot.prototype._attachSteamFriendRelationshipEvent = function() {
             // Log message and send welcome message
             logger("info", `[${this.logPrefix}] Added User: ` + steamID64);
 
-            if (this.index == 0) this.sendChatMessage(this, { steamID64: steamID64 }, this.controller.data.lang.useradded.replace(/cmdprefix/g, "!"));
+            if (this.index == 0) this.sendChatMessage(this, { userID: steamID64 }, this.controller.data.lang.useradded.replace(/cmdprefix/g, "!"));
 
 
             // Add user to lastcomment database

--- a/src/bot/events/webSession.js
+++ b/src/bot/events/webSession.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 29.06.2023 22:35:03
+ * Last Modified: 10.07.2023 09:33:16
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -64,7 +64,7 @@ Bot.prototype._attachSteamWebSessionEvent = function() {
                     logger("info", `[${this.logPrefix}] Added user while I was offline! User: ` + thisfriend);
 
                     setTimeout(() => {
-                        if (this.index == 0) this.sendChatMessage(this, { steamID64: String(thisfriend) }, this.controller.data.lang.useradded.replace(/cmdprefix/g, "!"));
+                        if (this.index == 0) this.sendChatMessage(this, { userID: String(thisfriend) }, this.controller.data.lang.useradded.replace(/cmdprefix/g, "!"));
                             else logger("debug", "Not sending useradded message because this isn't the main user...");
                     }, 1000 * processedFriendRequests);
 

--- a/src/bot/helpers/checkMsgBlock.js
+++ b/src/bot/helpers/checkMsgBlock.js
@@ -4,7 +4,7 @@
  * Created Date: 20.03.2023 12:46:47
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 17:55:45
+ * Last Modified: 10.07.2023 09:33:21
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -40,7 +40,7 @@ Bot.prototype.checkMsgBlock = function(steamID64, message) {
     if (lastmessage[steamID64] && lastmessage[steamID64][0] + this.controller.data.advancedconfig.commandCooldown > Date.now() && lastmessage[steamID64][1] > 5) return true; // Just don't respond
 
     if (lastmessage[steamID64] && lastmessage[steamID64][0] + this.controller.data.advancedconfig.commandCooldown > Date.now() && lastmessage[steamID64][1] > 4) { // Inform the user about the cooldown
-        this.sendChatMessage({ steamID: steamID64, prefix: "/me" }, this.controller.data.lang.userspamblock);
+        this.sendChatMessage({ userID: steamID64, prefix: "/me" }, this.controller.data.lang.userspamblock);
         logger("info", `${steamID64} has been blocked for 90 seconds for spamming.`);
 
         lastmessage[steamID64][0] += 90000;
@@ -54,7 +54,7 @@ Bot.prototype.checkMsgBlock = function(steamID64, message) {
 
     // Deny non-friends the use of any command
     if (this.user.myFriends[steamID64] != 3) {
-        this.sendChatMessage({ steamID: steamID64, prefix: "/me" }, this.controller.data.lang.usernotfriend);
+        this.sendChatMessage({ userID: steamID64, prefix: "/me" }, this.controller.data.lang.usernotfriend);
         return true;
     }
 

--- a/src/bot/helpers/checkMsgBlock.js
+++ b/src/bot/helpers/checkMsgBlock.js
@@ -4,7 +4,7 @@
  * Created Date: 20.03.2023 12:46:47
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 09:33:21
+ * Last Modified: 10.07.2023 13:05:31
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -49,7 +49,7 @@ Bot.prototype.checkMsgBlock = function(steamID64, message) {
         return true;
     }
 
-    if (!this.controller.data.cachefile.ownerid.includes(steamID64)) lastmessage[steamID64][1]++; // Push new message to array if user isn't an owner
+    if (!this.controller.data.cachefile.ownerid.includes(steamID64)) lastmessage[steamID64][1]++; // Push new message to array if user isn't an owner (this function is only called for Steam Chat messages, not for plugins)
 
 
     // Deny non-friends the use of any command

--- a/src/bot/helpers/steamChatInteraction.js
+++ b/src/bot/helpers/steamChatInteraction.js
@@ -4,7 +4,7 @@
  * Created Date: 01.04.2023 21:09:00
  * Author: 3urobeat
  *
- * Last Modified: 08.07.2023 00:44:35
+ * Last Modified: 10.07.2023 09:29:15
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -39,7 +39,7 @@ Bot.prototype.sendChatMessage = function(_this, resInfo, txt, retry = 0, part = 
     if (!txt) return logger("warn", "sendChatMessage() was called without any message content! Ignoring call...");
     if (typeof txt !== "string") return logger("warn", "sendChatMessage() was called with txt that isn't a string! Ignoring call...");
 
-    let steamID64 = resInfo.steamID64;
+    let steamID64 = resInfo.userID;
 
     // Allow resInfo to overwrite char limit of 750 chars
     let limit = 750;

--- a/src/bot/helpers/steamChatInteraction.js
+++ b/src/bot/helpers/steamChatInteraction.js
@@ -4,7 +4,7 @@
  * Created Date: 01.04.2023 21:09:00
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 17:51:07
+ * Last Modified: 08.07.2023 00:44:35
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -29,7 +29,7 @@ const { cutStringsIntelligently } = require("../../controller/helpers/misc.js");
 /**
  * Our commandHandler respondModule implementation - Sends a message to a Steam user
  * @param {Bot} _this The Bot object context
- * @param {object} resInfo Object containing information passed to command by friendMessage event. Supported by this handler: prefix, charLimit, cutChars
+ * @param {import("../../commands/commandHandler").resInfo} resInfo Object containing information passed to command by friendMessage event. Supported by this handler: prefix, charLimit, cutChars
  * @param {string} txt The text to send
  * @param {number} retry Internal: Counter of retries for this part if sending failed
  * @param {number} part Internal: Index of which part to send for messages larger than charLimit chars

--- a/src/commands/commandHandler.js
+++ b/src/commands/commandHandler.js
@@ -4,7 +4,7 @@
  * Created Date: 01.04.2023 21:54:21
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:28:16
+ * Last Modified: 09.07.2023 17:26:54
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -220,7 +220,7 @@ CommandHandler.prototype.runCommand = function(name, args, respondModule, contex
     if (!resInfo || !resInfo.cmdprefix) resInfo["cmdprefix"] = "!";
 
     // Run command if one was found
-    thisCmd.run(this, args, steamID64, respondModule, context, resInfo);
+    thisCmd.run(this, args, respondModule, context, resInfo);
 
     // Return true if command was found
     return true;

--- a/src/commands/commandHandler.js
+++ b/src/commands/commandHandler.js
@@ -4,7 +4,7 @@
  * Created Date: 01.04.2023 21:54:21
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 09:48:25
+ * Last Modified: 10.07.2023 12:04:38
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -180,7 +180,7 @@ CommandHandler.prototype.unregisterCommand = function(commandName) {
  * @property {Array.<string>} [ownerIDs] Can be provided to overwrite `config.ownerid` for owner privilege checks. Useful if you are implementing a different platform and so `userID` won't be a steamID64 (e.g. discord)
  * @property {number} [charLimit] Supported by the Steam Chat Message handler: Overwrites the default index from which response messages will be cut up into parts
  * @property {Array.<string>} [cutChars] Custom chars to search after for cutting string in parts to overwrite cutStringsIntelligently's default: [" ", "\n", "\r"]
- * @property {boolean} [fromSteamChat] Set to true if your command handler is receiving messages from the Steam Chat and so `userID` can be expected to be a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
+ * @property {boolean} [fromSteamChat] Set to true if your command handler is receiving messages from the Steam Chat and `userID` is therefore a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
  * @property {string} [prefix] Do not provide this argument, you'll receive it from commands: Steam Chat Message prefixes like /me. Can be ignored or translated to similar prefixes your platform might support
  */
 

--- a/src/commands/commandHandler.js
+++ b/src/commands/commandHandler.js
@@ -4,7 +4,7 @@
  * Created Date: 01.04.2023 21:54:21
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:52:46
+ * Last Modified: 09.07.2023 13:28:16
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -173,16 +173,28 @@ CommandHandler.prototype.unregisterCommand = function(commandName) {
 
 
 /**
+ * @typedef resInfo Documentation of the default/commonly used content the resInfo object can/should contain
+ * @type {object}
+ * @property {string} [cmdprefix] Prefix your command execution handler uses. This will be used in response messages referencing commands. Default: !
+ * @property {string} userID ID of the user who executed this command. Will be used for command default behavior (e.g. commenting on the requester's profile), to check for owner privileges, apply cooldowns and maybe your respondModule implementation for responding. Strongly advised to include.
+ * @property {Array.<string>} [ownerIDs] Can be provided to overwrite `config.ownerid` for owner privilege checks. Useful if you are implementing a different platform and so `userID` won't be a steamID64 (e.g. discord)
+ * @property {number} [charLimit] Supported by the Steam Chat Message handler: Overwrites the default index from which response messages will be cut up into parts
+ * @property {Array.<string>} [cutChars] Custom chars to search after for cutting string in parts to overwrite cutStringsIntelligently's default: [" ", "\n", "\r"]
+ * @property {boolean} [fromSteamChat] Set to true if your command handler is receiving messages from the Steam Chat and so `userID` can be expected to be a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
+ * @property {string} [prefix] Do not provide this argument, you'll receive it from commands: Steam Chat Message prefixes like /me. Can be ignored or translated to similar prefixes your platform might support
+ */
+
+
+/**
  * Finds a loaded command by name and runs it
  * @param {string} name The name of the command
  * @param {Array} args Array of arguments that will be passed to the command
- * @param {number} steamID64 SteamID64 of the requesting user which is used to check for ownerOnly and will be passed to the command
  * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
- * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
- * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command). Please also include a "cmdprefix" key & value pair if your command handler uses a prefix other than "!".
+ * @param {object} context The context (`this.`) of the object calling this command. Will be passed to respondModule() as first parameter to make working in this function easier.
+ * @param {resInfo} resInfo Object containing additional information
  * @returns {boolean} `true` if command was found, `false` if not
  */
-CommandHandler.prototype.runCommand = function(name, args, steamID64, respondModule, context, resInfo) {
+CommandHandler.prototype.runCommand = function(name, args, respondModule, context, resInfo) {
 
     // Iterate through all command objects in commands array and check if name is included in names array of each command.
     let thisCmd = this.commands.find(e => e.names.includes(name));

--- a/src/commands/core/block.js
+++ b/src/commands/core/block.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:51:40
+ * Last Modified: 09.07.2023 13:28:44
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -41,7 +41,7 @@ module.exports.block = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -86,7 +86,7 @@ module.exports.unblock = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/block.js
+++ b/src/commands/core/block.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:28:56
+ * Last Modified: 10.07.2023 12:58:49
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -49,9 +49,13 @@ module.exports.block = {
 
         if (!args[0]) return respond(commandHandler.data.lang.invalidprofileid);
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         commandHandler.controller.handleSteamIdResolving(args[0], "profile", (err, res) => {
             if (err) return respond(commandHandler.data.lang.invalidprofileid + "\n\nError: " + err);
-            if (commandHandler.data.cachefile.ownerid.includes(res)) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.idisownererror); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
+            if (owners.includes(res)) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.idisownererror); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
             commandHandler.controller.getBots().forEach((e, i) => {
                 e.user.blockUser(new SteamID(res), (err) => { if (err) logger("error", `[Bot ${i}] Error blocking user ${res}: ${err}`); });

--- a/src/commands/core/block.js
+++ b/src/commands/core/block.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:28:44
+ * Last Modified: 09.07.2023 17:28:56
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -38,12 +38,11 @@ module.exports.block = {
      * The block command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -83,12 +82,11 @@ module.exports.unblock = {
      * The unblock command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained

--- a/src/commands/core/comment.js
+++ b/src/commands/core/comment.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 10:45:31
+ * Last Modified: 10.07.2023 12:49:36
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -76,6 +76,9 @@ module.exports.comment = {
         if (commandHandler.controller.info.readyAfter == 0)             return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         if (commandHandler.controller.info.activeLogin)                 return respond(commandHandler.data.lang.activerelog);      // Bot is waiting for relog
         if (commandHandler.data.config.maxComments == 0 && !ownercheck) return respond(commandHandler.data.lang.commandowneronly); // Comment command is restricted to owners only
+
+        // Check for no id param as default behavior is unavailable when calling from outside the Steam Chat
+        if (!resInfo.fromSteamChat && !args[1]) return respond(commandHandler.data.lang.noidparam);
 
 
         /* --------- Calculate maxRequestAmount and get arguments from comment request --------- */

--- a/src/commands/core/comment.js
+++ b/src/commands/core/comment.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:51:55
+ * Last Modified: 09.07.2023 13:29:18
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -59,7 +59,7 @@ module.exports.comment = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -216,7 +216,7 @@ module.exports.comment = {
 /**
  * Internal: Do the actual commenting, activeRequests entry with all relevant information was processed by the comment command function above.
  * @param {CommandHandler} commandHandler The commandHandler object
- * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+ * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
  * @param {function(string): void} respond The shortened respondModule call
  * @param {Function} postComment The correct postComment function for this idType. Context from the correct bot account is being applied later.
  * @param {object} commentArgs All arguments this postComment function needs, without callback. It will be applied and a callback added as last param. Include a key called "quote" to dynamically replace it with a random quote.

--- a/src/commands/core/comment.js
+++ b/src/commands/core/comment.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:28:42
+ * Last Modified: 10.07.2023 10:45:31
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -63,12 +63,16 @@ module.exports.comment = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
-        let requesterSteamID64 = steamID64;
+        let requesterSteamID64 = resInfo.userID;
         let receiverSteamID64  = requesterSteamID64;
         let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
 
 
-        /* --------- Check for disabled comment cmd or if update is queued --------- */
+        /* --------- Various checks  --------- */
+        if (!resInfo.userID) {
+            respond(commandHandler.data.lang.nouserid); // Reject usage of command without an userID to avoid cooldown bypass
+            return logger("err", "The comment command was called without resInfo.userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command!");
+        }
         if (commandHandler.controller.info.readyAfter == 0)             return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         if (commandHandler.controller.info.activeLogin)                 return respond(commandHandler.data.lang.activerelog);      // Bot is waiting for relog
         if (commandHandler.data.config.maxComments == 0 && !ownercheck) return respond(commandHandler.data.lang.commandowneronly); // Comment command is restricted to owners only
@@ -186,7 +190,7 @@ module.exports.comment = {
         if (idType == "profile") {
             commandHandler.controller.main.community.getSteamUser(new SteamID(receiverSteamID64), (err, user) => {
                 if (err) {
-                    logger("warn", `[Main] Failed to check if ${steamID64} is private: ${err}\n       Trying to comment anyway and hoping no error occurs...`); // This can happen sometimes and most of the times commenting will still work
+                    logger("warn", `[Main] Failed to check if ${receiverSteamID64} is private: ${err}\n       Trying to comment anyway and hoping no error occurs...`); // This can happen sometimes and most of the times commenting will still work
                 } else {
                     logger("debug", "Successfully checked privacyState of receiving user: " + user.privacyState);
 

--- a/src/commands/core/comment.js
+++ b/src/commands/core/comment.js
@@ -63,9 +63,13 @@ module.exports.comment = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         let requesterSteamID64 = resInfo.userID;
         let receiverSteamID64  = requesterSteamID64;
-        let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
+        let ownercheck         = owners.includes(requesterSteamID64);
 
 
         /* --------- Various checks  --------- */

--- a/src/commands/core/comment.js
+++ b/src/commands/core/comment.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:29:18
+ * Last Modified: 09.07.2023 17:28:42
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -56,12 +56,11 @@ module.exports.comment = {
      * The comment command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         let requesterSteamID64 = steamID64;

--- a/src/commands/core/favorite.js
+++ b/src/commands/core/favorite.js
@@ -4,7 +4,7 @@
  * Created Date: 02.06.2023 13:23:01
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:53:13
+ * Last Modified: 09.07.2023 13:29:45
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -50,7 +50,7 @@ module.exports.favorite = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -233,7 +233,7 @@ module.exports.unfavorite = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/favorite.js
+++ b/src/commands/core/favorite.js
@@ -4,7 +4,7 @@
  * Created Date: 02.06.2023 13:23:01
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 10:45:09
+ * Last Modified: 10.07.2023 12:59:36
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -54,8 +54,12 @@ module.exports.favorite = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         let requesterSteamID64 = resInfo.userID;
-        let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
+        let ownercheck         = owners.includes(requesterSteamID64);
 
 
         /* --------- Various checks  --------- */
@@ -240,8 +244,12 @@ module.exports.unfavorite = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         let requesterSteamID64 = resInfo.userID;
-        let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
+        let ownercheck         = owners.includes(requesterSteamID64);
 
 
         /* --------- Various checks  --------- */

--- a/src/commands/core/favorite.js
+++ b/src/commands/core/favorite.js
@@ -4,7 +4,7 @@
  * Created Date: 02.06.2023 13:23:01
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:29:25
+ * Last Modified: 10.07.2023 10:45:09
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -54,11 +54,15 @@ module.exports.favorite = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
-        let requesterSteamID64 = steamID64;
+        let requesterSteamID64 = resInfo.userID;
         let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
 
 
-        /* --------- Check for disabled cmd or if update is queued --------- */
+        /* --------- Various checks  --------- */
+        if (!resInfo.userID) {
+            respond(commandHandler.data.lang.nouserid); // Reject usage of command without an userID to avoid cooldown bypass
+            return logger("err", "The favorite command was called without resInfo.userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command!");
+        }
         if (commandHandler.controller.info.readyAfter == 0)             return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         if (commandHandler.controller.info.activeLogin)                 return respond(commandHandler.data.lang.activerelog);      // Bot is waiting for relog
         if (commandHandler.data.config.maxComments == 0 && !ownercheck) return respond(commandHandler.data.lang.commandowneronly); // Command is restricted to owners only
@@ -236,11 +240,15 @@ module.exports.unfavorite = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
-        let requesterSteamID64 = steamID64;
+        let requesterSteamID64 = resInfo.userID;
         let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
 
 
-        /* --------- Check for disabled cmd or if update is queued --------- */
+        /* --------- Various checks  --------- */
+        if (!resInfo.userID) {
+            respond(commandHandler.data.lang.nouserid); // Reject usage of command without an userID to avoid cooldown bypass
+            return logger("err", "The unfavorite command was called without resInfo.userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command!");
+        }
         if (commandHandler.controller.info.readyAfter == 0)             return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         if (commandHandler.controller.info.activeLogin)                 return respond(commandHandler.data.lang.activerelog);      // Bot is waiting for relog
         if (commandHandler.data.config.maxComments == 0 && !ownercheck) return respond(commandHandler.data.lang.commandowneronly); // Command is restricted to owners only

--- a/src/commands/core/favorite.js
+++ b/src/commands/core/favorite.js
@@ -4,7 +4,7 @@
  * Created Date: 02.06.2023 13:23:01
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:29:45
+ * Last Modified: 09.07.2023 17:29:25
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -47,12 +47,11 @@ module.exports.favorite = {
      * The favorite command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         let requesterSteamID64 = steamID64;
@@ -230,12 +229,11 @@ module.exports.unfavorite = {
      * The unfavorite command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         let requesterSteamID64 = steamID64;

--- a/src/commands/core/friend.js
+++ b/src/commands/core/friend.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:29:35
+ * Last Modified: 10.07.2023 12:16:57
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -115,14 +115,17 @@ module.exports.unfriend = {
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
-        // Unfriend message sender with all bot accounts if no id was provided
-        if (!args[0]) {
+        // Check for no args again as the default behavior from above might be unavailable when calling from outside of the Steam Chat
+        if (!args[0] && !resInfo.fromSteamChat) return respond(commandHandler.data.lang.noidparam);
+
+        // Unfriend message sender with all bot accounts if no id was provided and the command was called from the steam chat
+        if (!args[0] && resInfo.userID && resInfo.fromSteamChat) {
             respond(commandHandler.data.lang.unfriendcmdsuccess);
-            logger("info", `Removing friend ${steamID64} from all bot accounts...`);
+            logger("info", `Removing friend ${resInfo.userID} from all bot accounts...`);
 
             commandHandler.controller.getBots().forEach((e, i) => {
                 setTimeout(() => {
-                    e.user.removeFriend(new SteamID(steamID64));
+                    e.user.removeFriend(new SteamID(resInfo.userID));
                 }, 1000 * i);
             });
 

--- a/src/commands/core/friend.js
+++ b/src/commands/core/friend.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:57:36
+ * Last Modified: 09.07.2023 13:29:57
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -41,7 +41,7 @@ module.exports.addFriend = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -110,7 +110,7 @@ module.exports.unfriend = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -172,7 +172,7 @@ module.exports.unfriendall = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/friend.js
+++ b/src/commands/core/friend.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:29:57
+ * Last Modified: 09.07.2023 17:29:35
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -38,12 +38,11 @@ module.exports.addFriend = {
      * The addFriend command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -107,12 +106,11 @@ module.exports.unfriend = {
      * The unfriend command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -169,12 +167,11 @@ module.exports.unfriendall = {
      * The unfriendall command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained

--- a/src/commands/core/friend.js
+++ b/src/commands/core/friend.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 12:16:57
+ * Last Modified: 10.07.2023 13:02:11
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -131,12 +131,16 @@ module.exports.unfriend = {
 
         } else {
 
+            // Get the correct ownerid array for this request
+            let owners = commandHandler.data.cachefile.ownerid;
+            if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
             // Unfriending a specific user is owner only
-            if (!commandHandler.data.cachefile.ownerid.includes(steamID64)) return respond(commandHandler.data.lang.commandowneronly);
+            if (!owners.includes(resInfo.userID)) return respond(commandHandler.data.lang.commandowneronly);
 
             commandHandler.controller.handleSteamIdResolving(args[0], "profile", (err, res) => {
                 if (err) return respond(commandHandler.data.lang.invalidprofileid + "\n\nError: " + err);
-                if (commandHandler.data.cachefile.ownerid.includes(res)) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.idisownererror); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
+                if (commandHandler.data.cachefile.ownerid.includes(res)) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.idisownererror); // Check for the "original" ownerid array here, we don't care about non Steam IDs
 
                 commandHandler.controller.getBots().forEach((e, i) => {
                     setTimeout(() => {
@@ -201,7 +205,7 @@ module.exports.unfriendall = {
                         setTimeout(() => {
                             let friendSteamID = new SteamID(String(friend));
 
-                            if (!commandHandler.data.cachefile.ownerid.includes(friend)) {
+                            if (!commandHandler.data.cachefile.ownerid.includes(friend)) { // Check for the "original" ownerid array here, we don't care about non Steam IDs
                                 logger("info", `Removing friend ${friendSteamID.getSteamID64()} from all bot accounts...`, false, false, logger.animation("loading"));
                                 commandHandler.controller.getBots()[i].user.removeFriend(friendSteamID);
                             } else {

--- a/src/commands/core/general.js
+++ b/src/commands/core/general.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 12:02:38
+ * Last Modified: 10.07.2023 13:02:40
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -39,10 +39,14 @@ module.exports.help = {
     run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         // Construct comment text for owner or non owner
         let commentText;
 
-        if (commandHandler.data.cachefile.ownerid.includes(steamID64)) {
+        if (owners.includes(resInfo.userID)) {
             if (commandHandler.controller.getBots().length > 1 || commandHandler.data.config.maxOwnerComments) commentText = `'${resInfo.cmdprefix}comment (amount/"all") [profileid] [custom, quotes]' - ${commandHandler.data.lang.helpcommentowner1.replace("maxOwnerComments", commandHandler.data.config.maxOwnerComments)}`;
                 else commentText = `'${resInfo.cmdprefix}comment ("1") [profileid] [custom, quotes]' - ${commandHandler.data.lang.helpcommentowner2}`;
         } else {
@@ -88,6 +92,10 @@ module.exports.info = {
      */
     run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
+
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
 
         commandHandler.data.lastCommentDB.findOne({ id: resInfo.userID }, async (err, doc) => {
             let lastReq = await commandHandler.data.getLastCommentRequest();

--- a/src/commands/core/general.js
+++ b/src/commands/core/general.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:29:54
+ * Last Modified: 10.07.2023 12:02:38
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -89,7 +89,7 @@ module.exports.info = {
     run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
-        commandHandler.data.lastCommentDB.findOne({ id: steamID64 }, async (err, doc) => {
+        commandHandler.data.lastCommentDB.findOne({ id: resInfo.userID }, async (err, doc) => {
             let lastReq = await commandHandler.data.getLastCommentRequest();
 
             let userLastReq = "Never";
@@ -103,7 +103,7 @@ module.exports.info = {
                 >   'node.js' Version: ${process.version} | RAM Usage (RSS): ${Math.round(process.memoryUsage()["rss"] / 1024 / 1024 * 100) / 100} MB
                 >   Accounts: ${commandHandler.controller.getBots().length} | maxComments/owner: ${commandHandler.data.config.maxComments}/${commandHandler.data.config.maxOwnerComments} | delay: ${commandHandler.data.config.commentdelay}
                 |
-                >   Your steam64ID: ${steamID64}
+                >   Your ID: ${resInfo.userID} | From Steam Chat? ${resInfo.fromSteamChat ? "Yes" : "No"} | Owner? ${owners.includes(resInfo.userID) ? "Yes" : "No"}
                 >   Your last request: ${userLastReq}
                 >   Last processed request: ${(new Date(lastReq)).toISOString().replace(/T/, " ").replace(/\..+/, "")} (GMT time)
                 >   I have commented ${commandHandler.controller.info.commentCounter} times since my last restart and completed request!

--- a/src/commands/core/general.js
+++ b/src/commands/core/general.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 11:25:17
+ * Last Modified: 09.07.2023 13:30:17
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -35,7 +35,7 @@ module.exports.help = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -86,7 +86,7 @@ module.exports.info = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -130,7 +130,7 @@ module.exports.ping = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond   = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -158,7 +158,7 @@ module.exports.about = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -181,7 +181,7 @@ module.exports.owner = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -208,7 +208,7 @@ module.exports.test = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // eslint-disable-line

--- a/src/commands/core/general.js
+++ b/src/commands/core/general.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:30:17
+ * Last Modified: 09.07.2023 17:29:54
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -32,12 +32,11 @@ module.exports.help = {
      * The help command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         // Construct comment text for owner or non owner
@@ -83,12 +82,11 @@ module.exports.info = {
      * The info command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         commandHandler.data.lastCommentDB.findOne({ id: steamID64 }, async (err, doc) => {
@@ -127,12 +125,11 @@ module.exports.ping = {
      * The ping command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond   = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         let pingStart = Date.now();
 
@@ -155,12 +152,11 @@ module.exports.about = {
      * The about command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         respond(commandHandler.data.datafile.aboutstr);
@@ -178,12 +174,11 @@ module.exports.owner = {
      * The owner command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         // Check if no owner link is set
@@ -205,12 +200,11 @@ module.exports.test = {
      * The test command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // eslint-disable-line
 
         /* // Do not remove, these are handleSteamIdResolving test cases. Might be useful to include later in steamid-resolving lib test suite

--- a/src/commands/core/group.js
+++ b/src/commands/core/group.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:30:08
+ * Last Modified: 10.07.2023 12:20:12
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -39,12 +39,13 @@ module.exports.group = {
 
         if (commandHandler.data.config.yourgroup.length < 1 || !commandHandler.data.cachefile.configgroup64id) return respond(commandHandler.data.lang.groupcmdnolink); // No group info at all? stop.
 
-        if (commandHandler.data.cachefile.configgroup64id && Object.keys(commandHandler.controller.main.user.myGroups).includes(commandHandler.data.cachefile.configgroup64id)) {
-            commandHandler.controller.main.user.inviteToGroup(steamID64, commandHandler.data.cachefile.configgroup64id);
+        // Send user an invite if a group is set in the config and userID is a Steam ID by checking fromSteamChat
+        if (resInfo.userID && resInfo.fromSteamChat && commandHandler.data.cachefile.configgroup64id && Object.keys(commandHandler.controller.main.user.myGroups).includes(commandHandler.data.cachefile.configgroup64id)) {
+            commandHandler.controller.main.user.inviteToGroup(resInfo.userID, commandHandler.data.cachefile.configgroup64id);
             respond(commandHandler.data.lang.groupcmdinvitesent);
 
             if (commandHandler.data.cachefile.configgroup64id != "103582791464712227") { // https://steamcommunity.com/groups/3urobeatGroup
-                commandHandler.controller.main.user.inviteToGroup(steamID64, new SteamID("103582791464712227"));
+                commandHandler.controller.main.user.inviteToGroup(resInfo.userID, new SteamID("103582791464712227"));
             }
             return; // Id? send invite and stop
         }

--- a/src/commands/core/group.js
+++ b/src/commands/core/group.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 16:01:25
+ * Last Modified: 09.07.2023 13:30:28
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -33,7 +33,7 @@ module.exports.group = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -76,7 +76,7 @@ module.exports.joinGroup = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -122,7 +122,7 @@ module.exports.leaveGroup = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -168,7 +168,7 @@ module.exports.leaveAllGroups = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/group.js
+++ b/src/commands/core/group.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:30:28
+ * Last Modified: 09.07.2023 17:30:08
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -30,12 +30,11 @@ module.exports.group = {
      * The group command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.data.config.yourgroup.length < 1 || !commandHandler.data.cachefile.configgroup64id) return respond(commandHandler.data.lang.groupcmdnolink); // No group info at all? stop.
@@ -73,12 +72,11 @@ module.exports.joinGroup = {
      * The joinGroup command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -119,12 +117,11 @@ module.exports.leaveGroup = {
      * The leaveGroup command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -165,12 +162,11 @@ module.exports.leaveAllGroups = {
      * The leaveAllGroups command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained

--- a/src/commands/core/requests.js
+++ b/src/commands/core/requests.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:30:33
+ * Last Modified: 10.07.2023 12:26:58
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -45,23 +45,28 @@ module.exports.abort = {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
+        let userID = resInfo.userID;
+
+        // Check for no userID and no id param as both can be missing if called from outside the Steam Chat
+        if (!userID && !args[0]) return respond(commandHandler.data.lang.noidparam);
+
         commandHandler.controller.handleSteamIdResolving(args[0], null, (err, res) => {
             if (res) {
                 let activeReqEntry = commandHandler.controller.activeRequests[res];
 
                 // Refuse if user is not an owner and the request is not from them
-                if (!commandHandler.data.cachefile.ownerid.includes(steamID64) && (activeReqEntry && activeReqEntry.requestedby != steamID64)) return respond(commandHandler.data.lang.commandowneronly);
+                if (!commandHandler.data.cachefile.ownerid.includes(resInfo.userID) && (activeReqEntry && activeReqEntry.requestedby != resInfo.userID)) return respond(commandHandler.data.lang.commandowneronly);
                     else logger("debug", "CommandHandler abort cmd: Non-owner provided ID as parameter but is requester of that request. Permitting abort...");
 
-                steamID64 = res; // If user provided an id as argument then use that instead of their id
+                userID = res; // If user provided an id as argument then use that instead of their id
             }
 
-            if (!commandHandler.controller.activeRequests[steamID64] || commandHandler.controller.activeRequests[steamID64].status != "active") return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.abortcmdnoprocess); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
+            if (!commandHandler.controller.activeRequests[userID] || commandHandler.controller.activeRequests[userID].status != "active") return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.abortcmdnoprocess); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
             // Set new status for this request
-            commandHandler.controller.activeRequests[steamID64].status = "aborted";
+            commandHandler.controller.activeRequests[userID].status = "aborted";
 
-            logger("info", `Aborting active process for ID ${steamID64}...`);
+            logger("info", `Aborting active process for ID ${userID}...`);
             respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.abortcmdsuccess); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         });
     }
@@ -104,15 +109,20 @@ module.exports.resetCooldown = {
 
         } else {
 
+            let userID = resInfo.userID;
+
+            // Check for no userID and no id param as both can be missing if called from outside the Steam Chat
+            if (!userID && !args[0]) return respond(commandHandler.data.lang.noidparam);
+
             commandHandler.controller.handleSteamIdResolving(args[0], "profile", (err, res) => {
                 if (err) return respond(commandHandler.data.lang.invalidprofileid + "\n\nError: " + err);
-                if (res) steamID64 = res; // Change steamID64 to the provided id
+                if (res) userID = res; // Change steamID64 to the provided id
 
                 if (commandHandler.data.config.commentcooldown == 0) return respond(commandHandler.data.lang.resetcooldowncmdcooldowndisabled); // Is the cooldown enabled?
 
-                commandHandler.data.lastCommentDB.update({ id: steamID64 }, { $set: { time: Date.now() - (commandHandler.data.config.commentcooldown * 60000) } }, (err) => {
+                commandHandler.data.lastCommentDB.update({ id: userID }, { $set: { time: Date.now() - (commandHandler.data.config.commentcooldown * 60000) } }, (err) => {
                     if (err) return respond("Error updating database entry: " + err);
-                        else respond(commandHandler.data.lang.resetcooldowncmdsuccess.replace("profileid", steamID64.toString()));
+                        else respond(commandHandler.data.lang.resetcooldowncmdsuccess.replace("profileid", userID.toString()));
                 });
             });
         }
@@ -145,27 +155,32 @@ module.exports.failed = {
     run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        let userID = resInfo.userID;
+
+        // Check for no userID and no id param as both can be missing if called from outside the Steam Chat
+        if (!userID && !args[0]) return respond(commandHandler.data.lang.noidparam);
+
         commandHandler.controller.handleSteamIdResolving(args[0], null, (err, res) => {
             if (res) {
                 let activeReqEntry = commandHandler.controller.activeRequests[res];
 
                 // Refuse if user is not an owner and the request is not from them
-                if (!commandHandler.data.cachefile.ownerid.includes(steamID64) && (activeReqEntry && activeReqEntry.requestedby != steamID64)) return respond(commandHandler.data.lang.commandowneronly);
+                if (!commandHandler.data.cachefile.ownerid.includes(userID) && (activeReqEntry && activeReqEntry.requestedby != userID)) return respond(commandHandler.data.lang.commandowneronly);
                     else logger("debug", "CommandHandler failed cmd: Non-owner provided ID as parameter but is requester of that request. Permitting data retrieval...");
 
-                steamID64 = res; // If user provided an id as argument then use that instead of their id
+                userID = res; // If user provided an id as argument then use that instead of their id
             }
 
-            if (!commandHandler.controller.activeRequests[steamID64] || Object.keys(commandHandler.controller.activeRequests[steamID64].failed).length < 1) return respond(commandHandler.data.lang.failedcmdnothingfound);
+            if (!commandHandler.controller.activeRequests[userID] || Object.keys(commandHandler.controller.activeRequests[userID].failed).length < 1) return respond(commandHandler.data.lang.failedcmdnothingfound);
 
             // Get timestamp of request
-            let requestTime = new Date(commandHandler.controller.activeRequests[steamID64].until).toISOString().replace(/T/, " ").replace(/\..+/, "");
+            let requestTime = new Date(commandHandler.controller.activeRequests[userID].until).toISOString().replace(/T/, " ").replace(/\..+/, "");
 
             // Group errors and convert them to string using helper function
-            let failedcommentsstr = failedCommentsObjToString(commandHandler.controller.activeRequests[steamID64].failed);
+            let failedcommentsstr = failedCommentsObjToString(commandHandler.controller.activeRequests[userID].failed);
 
             // Get start of message from lang file and add data
-            let messagestart = commandHandler.data.lang.failedcmdmsg.replace("steamID64", steamID64).replace("requesttime", requestTime);
+            let messagestart = commandHandler.data.lang.failedcmdmsg.replace("steamID64", userID).replace("requesttime", requestTime);
 
             // Send message and limit to 500 chars as this call can cause many messages to be sent
             respondModule(context, { prefix: "/pre", charLimit: 500, ...resInfo }, messagestart + "\nc = Comment, b = Bot, p = Proxy\n\n" + failedcommentsstr); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -236,12 +251,15 @@ module.exports.mySessions = {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         let str = "";
 
+        // Check for no userID as the default behavior might be unavailable when calling from outside of the Steam Chat
+        if (!resInfo.userID) return respond(commandHandler.data.lang.nouserid); // In this case the cmd doesn't have an ID param so send this message instead of noidparam
+
         if (Object.keys(commandHandler.controller.activeRequests).length > 0) { // Only loop through object if it isn't empty
             let objlength = Object.keys(commandHandler.controller.activeRequests).length; // Save this before the loop as deleting entries will change this number and lead to the loop finished check never triggering
 
             Object.keys(commandHandler.controller.activeRequests).forEach((e, i) => {
                 if (Date.now() < commandHandler.controller.activeRequests[e].until + (commandHandler.data.config.botaccountcooldown * 60000)) { // Check if entry is not finished yet
-                    if (commandHandler.controller.activeRequests[e].requestedby == steamID64) str += `- Status: ${commandHandler.controller.activeRequests[e].status} | ${commandHandler.controller.activeRequests[e].amount} iterations with ${commandHandler.controller.activeRequests[e].accounts.length} accounts by ${commandHandler.controller.activeRequests[e].requestedby} for ${commandHandler.controller.activeRequests[e].type} ${Object.keys(commandHandler.controller.activeRequests)[i]}`;
+                    if (commandHandler.controller.activeRequests[e].requestedby == resInfo.userID) str += `- Status: ${commandHandler.controller.activeRequests[e].status} | ${commandHandler.controller.activeRequests[e].amount} iterations with ${commandHandler.controller.activeRequests[e].accounts.length} accounts by ${commandHandler.controller.activeRequests[e].requestedby} for ${commandHandler.controller.activeRequests[e].type} ${Object.keys(commandHandler.controller.activeRequests)[i]}`;
                 } else {
                     delete commandHandler.controller.activeRequests[e]; // Remove entry from object if it is finished to keep the object clean
                 }

--- a/src/commands/core/requests.js
+++ b/src/commands/core/requests.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:58:36
+ * Last Modified: 09.07.2023 13:30:56
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -40,7 +40,7 @@ module.exports.abort = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -90,7 +90,7 @@ module.exports.resetCooldown = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -143,7 +143,7 @@ module.exports.failed = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -190,7 +190,7 @@ module.exports.sessions = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -235,7 +235,7 @@ module.exports.mySessions = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/requests.js
+++ b/src/commands/core/requests.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 12:26:58
+ * Last Modified: 10.07.2023 13:04:06
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -54,8 +54,12 @@ module.exports.abort = {
             if (res) {
                 let activeReqEntry = commandHandler.controller.activeRequests[res];
 
+                // Get the correct ownerid array for this request
+                let owners = commandHandler.data.cachefile.ownerid;
+                if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
                 // Refuse if user is not an owner and the request is not from them
-                if (!commandHandler.data.cachefile.ownerid.includes(resInfo.userID) && (activeReqEntry && activeReqEntry.requestedby != resInfo.userID)) return respond(commandHandler.data.lang.commandowneronly);
+                if (!owners.includes(resInfo.userID) && (activeReqEntry && activeReqEntry.requestedby != resInfo.userID)) return respond(commandHandler.data.lang.commandowneronly);
                     else logger("debug", "CommandHandler abort cmd: Non-owner provided ID as parameter but is requester of that request. Permitting abort...");
 
                 userID = res; // If user provided an id as argument then use that instead of their id
@@ -164,8 +168,12 @@ module.exports.failed = {
             if (res) {
                 let activeReqEntry = commandHandler.controller.activeRequests[res];
 
+                // Get the correct ownerid array for this request
+                let owners = commandHandler.data.cachefile.ownerid;
+                if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
                 // Refuse if user is not an owner and the request is not from them
-                if (!commandHandler.data.cachefile.ownerid.includes(userID) && (activeReqEntry && activeReqEntry.requestedby != userID)) return respond(commandHandler.data.lang.commandowneronly);
+                if (!owners.includes(userID) && (activeReqEntry && activeReqEntry.requestedby != userID)) return respond(commandHandler.data.lang.commandowneronly);
                     else logger("debug", "CommandHandler failed cmd: Non-owner provided ID as parameter but is requester of that request. Permitting data retrieval...");
 
                 userID = res; // If user provided an id as argument then use that instead of their id

--- a/src/commands/core/requests.js
+++ b/src/commands/core/requests.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:30:56
+ * Last Modified: 09.07.2023 17:30:33
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -37,12 +37,11 @@ module.exports.abort = {
      * The abort command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         if (commandHandler.controller.info.readyAfter == 0) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Check if bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
@@ -87,12 +86,11 @@ module.exports.resetCooldown = {
      * The resetcooldown command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         if (args[0] && args[0] == "global") { // Check if user wants to reset the global cooldown (will reset all until entries in activeRequests)
@@ -140,12 +138,11 @@ module.exports.failed = {
      * The failed command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         commandHandler.controller.handleSteamIdResolving(args[0], null, (err, res) => {
@@ -187,12 +184,11 @@ module.exports.sessions = {
      * The sessions command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         let str = "";
@@ -232,12 +228,11 @@ module.exports.mySessions = {
      * The mysessions command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         let str = "";
 

--- a/src/commands/core/settings.js
+++ b/src/commands/core/settings.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:59:10
+ * Last Modified: 09.07.2023 13:30:59
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -48,7 +48,7 @@ module.exports.settings = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/settings.js
+++ b/src/commands/core/settings.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:30:59
+ * Last Modified: 09.07.2023 17:30:43
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -45,12 +45,11 @@ module.exports.settings = {
      * The settings command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         let config  = commandHandler.data.config;
 

--- a/src/commands/core/system.js
+++ b/src/commands/core/system.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:59:30
+ * Last Modified: 09.07.2023 13:31:14
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -33,7 +33,7 @@ module.exports.restart = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.restartcmdrestarting); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -56,7 +56,7 @@ module.exports.stop = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.stopcmdstopping); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
@@ -79,7 +79,7 @@ module.exports.reload = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
 
@@ -117,7 +117,7 @@ module.exports.update = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((modResInfo, txt) => respondModule(context, modResInfo, txt)); // Shorten each call. Updater takes resInfo as param and can modify it, so we need to pass the modified resInfo object here
@@ -148,7 +148,7 @@ module.exports.output = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         fs.readFile("./output.txt", function (err, data) {
@@ -182,7 +182,7 @@ module.exports.eval = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/system.js
+++ b/src/commands/core/system.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:31:14
+ * Last Modified: 09.07.2023 17:31:02
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -30,12 +30,11 @@ module.exports.restart = {
      * The restart command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.restartcmdrestarting); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
         commandHandler.controller.restart(JSON.stringify({ skippedaccounts: commandHandler.controller.info.skippedaccounts }));
@@ -53,12 +52,11 @@ module.exports.stop = {
      * The stop command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.stopcmdstopping); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 
         commandHandler.controller.stop();
@@ -76,12 +74,11 @@ module.exports.reload = {
      * The reload command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
 
         // Reload commandHandler
         commandHandler.reloadCommands();
@@ -114,12 +111,11 @@ module.exports.update = {
      * The update command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((modResInfo, txt) => respondModule(context, modResInfo, txt)); // Shorten each call. Updater takes resInfo as param and can modify it, so we need to pass the modified resInfo object here
 
         // If the first argument is true then we shall force an update
@@ -145,12 +141,11 @@ module.exports.output = {
      * The output command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         fs.readFile("./output.txt", function (err, data) {
             if (err) logger("error", "error getting last 15 lines from output for log cmd: " + err);
 
@@ -179,12 +174,11 @@ module.exports.eval = {
      * The eval command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
         if (!commandHandler.data.advancedconfig.enableevalcmd) return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.evalcmdturnedoff); // Pass new resInfo object which contains prefix and everything the original resInfo obj contained
 

--- a/src/commands/core/vote.js
+++ b/src/commands/core/vote.js
@@ -4,7 +4,7 @@
  * Created Date: 28.05.2023 12:02:24
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 10:44:36
+ * Last Modified: 10.07.2023 13:03:44
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -54,8 +54,12 @@ module.exports.upvote = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         let requesterSteamID64 = resInfo.userID;
-        let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
+        let ownercheck         = owners.includes(requesterSteamID64);
 
 
         /* --------- Various checks  --------- */
@@ -245,8 +249,12 @@ module.exports.downvote = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         let requesterSteamID64 = resInfo.userID;
-        let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
+        let ownercheck         = owners.includes(requesterSteamID64);
 
 
         /* --------- Various checks  --------- */

--- a/src/commands/core/vote.js
+++ b/src/commands/core/vote.js
@@ -4,7 +4,7 @@
  * Created Date: 28.05.2023 12:02:24
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 17:31:22
+ * Last Modified: 10.07.2023 10:44:36
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -54,11 +54,15 @@ module.exports.upvote = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
-        let requesterSteamID64 = steamID64;
+        let requesterSteamID64 = resInfo.userID;
         let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
 
 
-        /* --------- Check for disabled cmd or if update is queued --------- */
+        /* --------- Various checks  --------- */
+        if (!resInfo.userID) {
+            respond(commandHandler.data.lang.nouserid); // Reject usage of command without an userID to avoid cooldown bypass
+            return logger("err", "The upvote command was called without resInfo.userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command!");
+        }
         if (commandHandler.controller.info.readyAfter == 0)             return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         if (commandHandler.controller.info.activeLogin)                 return respond(commandHandler.data.lang.activerelog);      // Bot is waiting for relog
         if (commandHandler.data.config.maxComments == 0 && !ownercheck) return respond(commandHandler.data.lang.commandowneronly); // Command is restricted to owners only
@@ -241,11 +245,15 @@ module.exports.downvote = {
     run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
-        let requesterSteamID64 = steamID64;
+        let requesterSteamID64 = resInfo.userID;
         let ownercheck         = commandHandler.data.cachefile.ownerid.includes(requesterSteamID64);
 
 
-        /* --------- Check for disabled cmd or if update is queued --------- */
+        /* --------- Various checks  --------- */
+        if (!resInfo.userID) {
+            respond(commandHandler.data.lang.nouserid); // Reject usage of command without an userID to avoid cooldown bypass
+            return logger("err", "The downvote command was called without resInfo.userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command!");
+        }
         if (commandHandler.controller.info.readyAfter == 0)             return respondModule(context, { prefix: "/me", ...resInfo }, commandHandler.data.lang.botnotready); // Bot isn't fully started yet - Pass new resInfo object which contains prefix and everything the original resInfo obj contained
         if (commandHandler.controller.info.activeLogin)                 return respond(commandHandler.data.lang.activerelog);      // Bot is waiting for relog
         if (commandHandler.data.config.maxComments == 0 && !ownercheck) return respond(commandHandler.data.lang.commandowneronly); // Command is restricted to owners only

--- a/src/commands/core/vote.js
+++ b/src/commands/core/vote.js
@@ -4,7 +4,7 @@
  * Created Date: 28.05.2023 12:02:24
  * Author: 3urobeat
  *
- * Last Modified: 07.07.2023 15:59:45
+ * Last Modified: 09.07.2023 13:31:20
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -50,7 +50,7 @@ module.exports.upvote = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
@@ -238,7 +238,7 @@ module.exports.downvote = {
      * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+     * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
     run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call

--- a/src/commands/core/vote.js
+++ b/src/commands/core/vote.js
@@ -4,7 +4,7 @@
  * Created Date: 28.05.2023 12:02:24
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:31:20
+ * Last Modified: 09.07.2023 17:31:22
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -47,12 +47,11 @@ module.exports.upvote = {
      * The upvote command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         let requesterSteamID64 = steamID64;
@@ -235,12 +234,11 @@ module.exports.downvote = {
      * The upvote command
      * @param {CommandHandler} commandHandler The commandHandler object
      * @param {Array} args Array of arguments that will be passed to the command
-     * @param {string} steamID64 Steam ID of the user that executed this command
      * @param {function(object, object, string): void} respondModule Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
      * @param {object} context The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
      * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      */
-    run: async (commandHandler, args, steamID64, respondModule, context, resInfo) => {
+    run: async (commandHandler, args, respondModule, context, resInfo) => {
         let respond = ((txt) => respondModule(context, resInfo, txt)); // Shorten each call
 
         let requesterSteamID64 = steamID64;

--- a/src/commands/helpers/getCommentArgs.js
+++ b/src/commands/helpers/getCommentArgs.js
@@ -4,7 +4,7 @@
  * Created Date: 28.02.2022 11:55:06
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 19:30:48
+ * Last Modified: 09.07.2023 13:31:23
  * Modified By: 3urobeat
  *
  * Copyright (c) 2022 3urobeat <https://github.com/3urobeat>
@@ -23,7 +23,7 @@ const CommandHandler = require("../commandHandler.js"); // eslint-disable-line
  * @param {CommandHandler} commandHandler The commandHandler object
  * @param {Array} args The command arguments
  * @param {string} requesterSteamID64 The steamID64 of the requesting user
- * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+ * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
  * @param {function(string): void} respond The shortened respondModule call
  * @returns {Promise.<{ maxRequestAmount: number, commentcmdUsage: string, numberOfComments: number, profileID: string, idType: string, quotesArr: Array.<string> }>} Resolves promise with object containing all relevant data when done
  */

--- a/src/commands/helpers/getCommentArgs.js
+++ b/src/commands/helpers/getCommentArgs.js
@@ -4,7 +4,7 @@
  * Created Date: 28.02.2022 11:55:06
  * Author: 3urobeat
  *
- * Last Modified: 09.07.2023 13:31:23
+ * Last Modified: 10.07.2023 12:51:53
  * Modified By: 3urobeat
  *
  * Copyright (c) 2022 3urobeat <https://github.com/3urobeat>
@@ -30,6 +30,10 @@ const CommandHandler = require("../commandHandler.js"); // eslint-disable-line
 module.exports.getCommentArgs = (commandHandler, args, requesterSteamID64, resInfo, respond) => {
     return new Promise((resolve) => {
 
+        // Get the correct ownerid array for this request
+        let owners = commandHandler.data.cachefile.ownerid;
+        if (resInfo.ownerIDs && resInfo.ownerIDs.length > 0) owners = resInfo.ownerIDs;
+
         let maxRequestAmount = commandHandler.data.config.maxComments; // Set to default value and if the requesting user is an owner it gets changed below
         let numberOfComments = 0;
         let quotesArr        = commandHandler.data.quotes;
@@ -41,7 +45,7 @@ module.exports.getCommentArgs = (commandHandler, args, requesterSteamID64, resIn
         /* --------- Define command usage messages & maxRequestAmount for each user's privileges --------- */
         let commentcmdUsage;
 
-        if (commandHandler.data.cachefile.ownerid.includes(requesterSteamID64)) {
+        if (owners.includes(requesterSteamID64)) {
             maxRequestAmount = commandHandler.data.config.maxOwnerComments;
 
             if (maxRequestAmount > 1) commentcmdUsage = commandHandler.data.lang.commentcmdusageowner.replace(/cmdprefix/g, resInfo.cmdprefix).replace("maxRequestAmount", maxRequestAmount);
@@ -77,7 +81,7 @@ module.exports.getCommentArgs = (commandHandler, args, requesterSteamID64, resIn
 
             /* --------- Check profileid argument if it was provided --------- */
             if (args[1]) {
-                if (commandHandler.data.cachefile.ownerid.includes(requesterSteamID64) || args[1] == requesterSteamID64) { // Check if user is a bot owner or if he provided his own profile id
+                if (owners.includes(requesterSteamID64) || args[1] == requesterSteamID64) { // Check if user is a bot owner or if he provided his own profile id
                     let arg = args[1];
 
                     commandHandler.controller.handleSteamIdResolving(arg, null, (err, res, type) => {

--- a/src/commands/helpers/getSharedfileArgs.js
+++ b/src/commands/helpers/getSharedfileArgs.js
@@ -4,7 +4,7 @@
  * Created Date: 28.05.2023 12:18:49
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 19:31:41
+ * Last Modified: 09.07.2023 13:31:26
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -23,7 +23,7 @@ const CommandHandler = require("../commandHandler.js"); // eslint-disable-line
  * @param {CommandHandler} commandHandler The commandHandler object
  * @param {Array} args The command arguments
  * @param {string} cmd Either "upvote", "downvote", "favorite" or "unfavorite", depending on which command is calling this function
- * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+ * @param {CommandHandler.resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
  * @param {function(string): void} respond The shortened respondModule call
  * @returns {Promise.<{ amount: number|string, id: string }>} If the user provided a specific amount, amount will be a number. If user provided "all" or "max", it will be returned as an unmodified string for getVoteBots.js to handle
  */

--- a/src/controller/controller.js
+++ b/src/controller/controller.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 06.07.2023 22:28:04
+ * Last Modified: 08.07.2023 00:47:49
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -68,7 +68,7 @@ const Controller = function() {
          * It is used by the steamChatInteraction helper but can be used in plugins as well.
          * @param {string} txt The string to cut
          * @param {number} limit Maximum length for each part. The function will attempt to cut txt into parts that don't exceed this amount.
-         * @param {Array} cutChars Optional: Custom chars to search after for cutting string in parts. Default: [" ", "\n", "\r"]
+         * @param {Array.<string>} cutChars Optional: Custom chars to search after for cutting string in parts. Default: [" ", "\n", "\r"]
          * @param {number} threshold Optional: Maximum amount that limit can be reduced to find the last space or line break. If no match is found within this limit a word will be cut. Default: 15% of total length
          * @returns {Array} Returns all parts of the string in an array
          */

--- a/src/controller/events/ready.js
+++ b/src/controller/events/ready.js
@@ -4,7 +4,7 @@
  * Created Date: 29.03.2023 12:23:29
  * Author: 3urobeat
  *
- * Last Modified: 29.06.2023 22:35:03
+ * Last Modified: 10.07.2023 09:33:30
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -152,7 +152,7 @@ Controller.prototype._readyEvent = function() {
     // Message all owners that are friends if firststart is true that the bot just updated itself
     if (this.data.datafile.firststart) {
         this.data.cachefile.ownerid.forEach((e) => {
-            if (!nonFriendOwners.includes(e)) this.main.sendChatMessage(this.main, { steamID64: e }, `I have updated myself to version ${this.data.datafile.versionstr}!\nWhat's new: ${this.data.datafile.whatsnew}`);
+            if (!nonFriendOwners.includes(e)) this.main.sendChatMessage(this.main, { userID: e }, `I have updated myself to version ${this.data.datafile.versionstr}!\nWhat's new: ${this.data.datafile.whatsnew}`);
         });
     }
 

--- a/src/controller/helpers/friendlist.js
+++ b/src/controller/helpers/friendlist.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 09:33:35
+ * Last Modified: 10.07.2023 13:10:14
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -134,7 +134,7 @@ Controller.prototype._lastcommentUnfriendCheck = function() {
                 this.getBots().forEach((f, j) => {
                     let thisbot = f.user;
 
-                    if (thisbot.myFriends[e.id] == 3 && !this.data.cachefile.ownerid.includes(e.id)) { // Check if the targeted user is still friend
+                    if (thisbot.myFriends[e.id] && thisbot.myFriends[e.id] == 3 && !this.data.cachefile.ownerid.includes(e.id)) { // Check if the targeted user is still friend and not an owner
                         if (j == 0) this.main.sendChatMessage(this.main, { userID: e.id }, this.data.lang.userforceunfriend.replace("unfriendtime", this.data.config.unfriendtime));
 
                         setTimeout(() => {
@@ -143,7 +143,8 @@ Controller.prototype._lastcommentUnfriendCheck = function() {
                         }, 1000 * j); // Delay every iteration so that we don't make a ton of requests at once (IP)
                     }
 
-                    if (!this.data.cachefile.ownerid.includes(e.id)) this.data.lastCommentDB.remove({ id: e.id }); // Entry gets removed no matter what but we are nice and let the owner stay. Thank me later! <3
+                    // Disabled db cleanup as entries from plugins would be deleted as well. SteamID does not recognize Discord IDs for example as invalid so we cannot check for that
+                    // if (!this.data.cachefile.ownerid.includes(e.id)) this.data.lastCommentDB.remove({ id: e.id }); // Entry gets removed no matter what but we are nice and let the owner stay. Thank me later! <3
                 });
 
             }, 1000 * i); // Delay every iteration so that we don't make a ton of requests at once (account)

--- a/src/controller/helpers/friendlist.js
+++ b/src/controller/helpers/friendlist.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 19:37:53
+ * Last Modified: 10.07.2023 09:33:35
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -88,7 +88,7 @@ Controller.prototype.friendListCapacityCheck = function(bot, callback) {
                                 let steamID = new SteamID(e.id);
 
                                 // Unfriend user and send him/her a message // TODO: Maybe only do this from the main bot?
-                                bot.sendChatMessage(bot, { steamID64: steamID.getSteamID64() }, this.data.lang.userunfriend.replace("forceFriendlistSpaceTime", this.data.advancedconfig.forceFriendlistSpaceTime));
+                                bot.sendChatMessage(bot, { userID: steamID.getSteamID64() }, this.data.lang.userunfriend.replace("forceFriendlistSpaceTime", this.data.advancedconfig.forceFriendlistSpaceTime));
                                 bot.user.removeFriend(steamID);
 
                                 logger("info", `[Bot ${bot.index}] Force-Unfriended ${e.id} after being inactive for ${this.data.advancedconfig.forceFriendlistSpaceTime} days to keep 1 empty slot on the friendlist`);
@@ -135,7 +135,7 @@ Controller.prototype._lastcommentUnfriendCheck = function() {
                     let thisbot = f.user;
 
                     if (thisbot.myFriends[e.id] == 3 && !this.data.cachefile.ownerid.includes(e.id)) { // Check if the targeted user is still friend
-                        if (j == 0) this.main.sendChatMessage(this.main, { steamID64: e.id }, this.data.lang.userforceunfriend.replace("unfriendtime", this.data.config.unfriendtime));
+                        if (j == 0) this.main.sendChatMessage(this.main, { userID: e.id }, this.data.lang.userforceunfriend.replace("unfriendtime", this.data.config.unfriendtime));
 
                         setTimeout(() => {
                             thisbot.removeFriend(new SteamID(e.id)); // Unfriend user with each bot

--- a/src/controller/helpers/misc.js
+++ b/src/controller/helpers/misc.js
@@ -4,7 +4,7 @@
  * Created Date: 25.03.2023 14:02:56
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 19:40:22
+ * Last Modified: 08.07.2023 00:47:33
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -127,7 +127,7 @@ module.exports.checkConnection = (url, throwTimeout) => {
  * It is used by the steamChatInteraction helper but can be used in plugins as well.
  * @param {string} txt The string to cut
  * @param {number} limit Maximum length for each part. The function will attempt to cut txt into parts that don't exceed this amount.
- * @param {Array} cutChars Optional: Custom chars to search after for cutting string in parts. Default: [" ", "\n", "\r"]
+ * @param {Array.<string>} cutChars Optional: Custom chars to search after for cutting string in parts. Default: [" ", "\n", "\r"]
  * @param {number} threshold Optional: Maximum amount that limit can be reduced to find the last space or line break. If no match is found within this limit a word will be cut. Default: 15% of total length
  * @returns {Array} Returns all parts of the string in an array
  */

--- a/src/data/lang/defaultlang.json
+++ b/src/data/lang/defaultlang.json
@@ -45,7 +45,8 @@
     "usernotfriend": "Please add me before using a command!",
     "botnotready": "The bot is not completely started yet. Please wait a moment before using a command.",
     "commandnotfound": "I don't know that command. Type cmdprefixhelp for more info.",
-    "commandowneronly": "This command is only available for owners.\nIf you are the botowner, make sure you added your ownerid to the config.json.",
+    "commandowneronly": "This command is only available for owners.\nIf you are the botowner, make sure you added your ownerid to the config.json.\nIf this request originates from a plugin, make sure to pass the userID & ownerIDs parameters.",
+    "nouserid": "The command was called without a userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command. This is a coding issue which must be fixed by a developer.",
 
     "invalidnumber": "This does not seem to be a valid number!\n\nCommand usage: cmdusage",
     "invalidprofileid": "This does not seem to be a valid ID or link or you provided the wrong ID type for this command!\nPlease make sure that you either provide a full link, only the vanity or only the ID, pointing to an existing profile, group or sharedfile.",

--- a/src/data/lang/defaultlang.json
+++ b/src/data/lang/defaultlang.json
@@ -46,7 +46,8 @@
     "botnotready": "The bot is not completely started yet. Please wait a moment before using a command.",
     "commandnotfound": "I don't know that command. Type cmdprefixhelp for more info.",
     "commandowneronly": "This command is only available for owners.\nIf you are the botowner, make sure you added your ownerid to the config.json.\nIf this request originates from a plugin, make sure to pass the userID & ownerIDs parameters.",
-    "nouserid": "The command was called without a userID! Blocking the command as I'm unable to apply cooldowns, which is required for this command. This is a coding issue which must be fixed by a developer.",
+    "nouserid": "The command was called without a userID! Blocking the command as I'm either unable to apply cooldowns or the default behavior of this command cannot be used without one. This is a coding issue which must be fixed by a developer.",
+    "noidparam": "Please provide an ID!\nThe default behavior of this command might be unavailable in this context, for example when the command was used from outside the Steam Chat or the developer forgot to pass a userID to enable it.",
 
     "invalidnumber": "This does not seem to be a valid number!\n\nCommand usage: cmdusage",
     "invalidprofileid": "This does not seem to be a valid ID or link or you provided the wrong ID type for this command!\nPlease make sure that you either provide a full link, only the vanity or only the ID, pointing to an existing profile, group or sharedfile.",

--- a/src/dataManager/helpers/handleCooldowns.js
+++ b/src/dataManager/helpers/handleCooldowns.js
@@ -4,7 +4,7 @@
  * Created Date: 13.04.2023 17:58:23
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 17:51:07
+ * Last Modified: 10.07.2023 10:31:28
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -93,6 +93,8 @@ DataManager.prototype.getUserCooldown = function(id) {
  * @param {number} timestamp Unix timestamp of the last interaction the user received
  */
 DataManager.prototype.setUserCooldown = function(id, timestamp) {
+    if (!id) return logger("error", "CRITICAL: setUserCooldown was called without an ID! I am unable to apply a cooldown for this user!\n                              Not fixing this error will render the cooldown system useless and exposes your accounts to the risk of getting banned!");
+
     logger("debug", `DataManager setUserCooldown(): Updating lastcomment db entry for ${id} to ${timestamp}.`);
 
     this.lastCommentDB.update({ id: id }, { $set: { time: timestamp } }, { upsert: true }, (err) => {

--- a/src/dataManager/helpers/handleCooldowns.js
+++ b/src/dataManager/helpers/handleCooldowns.js
@@ -4,7 +4,7 @@
  * Created Date: 13.04.2023 17:58:23
  * Author: 3urobeat
  *
- * Last Modified: 10.07.2023 10:31:28
+ * Last Modified: 10.07.2023 12:47:30
  * Modified By: 3urobeat
  *
  * Copyright (c) 2023 3urobeat <https://github.com/3urobeat>
@@ -35,7 +35,7 @@ DataManager.prototype.getUserCooldown = function(id) {
 
         this.lastCommentDB.findOne({ id: id }, (err, doc) => {
             if (!doc) { // Check if no entry was found and BAIL THE FUCK OUT
-                logger("warn", `User '${id}' has no lastComment database entry! Permitting request and hoping an entry will be inserted afterwards.\n                             If this warning appears multiple times for the same user you need to take action. Need help? https://github.com/3urobeat/steam-comment-service-bot/issues/new/choose`);
+                logger("warn", `User '${id}' has no lastComment database entry! Permitting request and hoping an entry will be inserted afterwards.\n                             If this warning appears multiple times for the same user you need to take action. Need help? https://github.com/3urobeat/steam-comment-service-bot/issues/new/choose\n                             If this warning is caused by a plugin for a userID from outside the Steam Chat for their first request you can ignore this warning as the behavior is to be expected.`);
                 return resolve(obj);
             }
 

--- a/src/dataManager/helpers/handleExpiringTokens.js
+++ b/src/dataManager/helpers/handleExpiringTokens.js
@@ -4,7 +4,7 @@
  * Created Date: 14.10.2022 14:58:25
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 20:00:28
+ * Last Modified: 10.07.2023 09:33:39
  * Modified By: 3urobeat
  *
  * Copyright (c) 2022 3urobeat <https://github.com/3urobeat>
@@ -72,7 +72,7 @@ DataManager.prototype._startExpiringTokensCheckInterval = function() {
                     _this.cachefile.ownerid.forEach((e, i) => {
                         setTimeout(() => {
                             // eslint-disable-next-line no-control-regex
-                            _this.controller.main.sendChatMessage(_this.controller.main, { steamID64: e }, msg.replace(/\x1B\[[0-9]+m/gm, "") + "!\nHead over to the terminal to refresh the token(s) now if you wish."); // Remove color codes from string
+                            _this.controller.main.sendChatMessage(_this.controller.main, { userID: e }, msg.replace(/\x1B\[[0-9]+m/gm, "") + "!\nHead over to the terminal to refresh the token(s) now if you wish."); // Remove color codes from string
                         }, 1500 * i);
                     });
 

--- a/src/updater/helpers/prepareUpdate.js
+++ b/src/updater/helpers/prepareUpdate.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 20:16:06
+ * Last Modified: 09.07.2023 13:31:38
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -22,7 +22,7 @@ const Controller = require("../../controller/controller.js"); // eslint-disable-
  * Wait for active requests and log off all bot accounts
  * @param {Controller} controller Reference to the controller object
  * @param {function(object, string): void} respondModule If defined, this function will be called with the result of the check. This allows to integrate checking for updates into commands or plugins. Passes resInfo and txt as parameters.
- * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+ * @param {import("../../commands/commandHandler.js").resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
  * @returns {Promise.<void>} Resolves when we can proceed
  */
 module.exports.run = (controller, respondModule, resInfo) => {

--- a/src/updater/updater.js
+++ b/src/updater/updater.js
@@ -4,7 +4,7 @@
  * Created Date: 09.07.2021 16:26:00
  * Author: 3urobeat
  *
- * Last Modified: 04.07.2023 20:17:07
+ * Last Modified: 09.07.2023 13:31:31
  * Modified By: 3urobeat
  *
  * Copyright (c) 2021 3urobeat <https://github.com/3urobeat>
@@ -49,7 +49,7 @@ module.exports = Updater;
  * Checks for any available update and installs it.
  * @param {boolean} forceUpdate If true an update will be forced, even if disableAutoUpdate is true or the newest version is already installed
  * @param {function(object, string): void} respondModule If defined, this function will be called with the result of the check. This allows to integrate checking for updates into commands or plugins. Passes resInfo and txt as parameters.
- * @param {object} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
+ * @param {import("../commands/commandHandler.js").resInfo} resInfo Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
  * @returns {Promise.<boolean>} Promise that will be resolved with false when no update was found or with true when the update check or download was completed. Expect a restart when true was returned.
  */
 Updater.prototype.run = function(forceUpdate, respondModule, resInfo) {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -51,7 +51,6 @@ declare class Bot {
     /**
      * Our commandHandler respondModule implementation - Sends a message to a Steam user
      * @param _this - The Bot object context
-     * @param resInfo - Object containing information passed to command by friendMessage event
      * @param txt - The text to send
      * @param retry - Internal: true if this message called itself again to send failure message
      * @param part - Internal: Index of which part to send for messages larger than 750 chars
@@ -114,7 +113,6 @@ declare class Bot {
     /**
      * Our commandHandler respondModule implementation - Sends a message to a Steam user
      * @param _this - The Bot object context
-     * @param resInfo - Object containing information passed to command by friendMessage event
      * @param txt - The text to send
      * @param retry - Internal: true if this message called itself again to send failure message
      * @param part - Internal: Index of which part to send for messages larger than 750 chars
@@ -145,9 +143,24 @@ declare namespace Bot {
  */
 declare type Command = {
     description: string;
-    args: { name: string; description: string; type: string; ownersOnly: boolean; }[];
+    args: CommandArg[];
     ownersOnly: boolean;
     run: (...params: any[]) => any;
+};
+
+/**
+ * @property name - Name of this argument. Use common phrases like "ID" or "amount" if possible. If a specific word is expected, put the word inside quotation marks.
+ * @property description - Description of this argument
+ * @property type - Expected datatype of this argument. If read from a chat it will usually be "string"
+ * @property isOptional - True if this argument is optional, false if it must be provided. Make sure to check for missing arguments and return an error if false.
+ * @property ownersOnly - True if this argument is only allowed to be provided by owners set in the config. If the command itself is `ownersOnly`, set this property to `true` as well.
+ */
+declare type CommandArg = {
+    name: string;
+    description: string;
+    type: string;
+    isOptional: boolean;
+    ownersOnly: boolean;
 };
 
 /**
@@ -181,18 +194,36 @@ declare class CommandHandler {
      * Finds a loaded command by name and runs it
      * @param name - The name of the command
      * @param args - Array of arguments that will be passed to the command
-     * @param steamID64 - SteamID64 of the requesting user which is used to check for ownerOnly and will be passed to the command
      * @param respondModule - Function that will be called to respond to the user's request. Passes context, resInfo and txt as parameters.
-     * @param context - The context (this.) of the object calling this command. Will be passed to respondModule() as first parameter.
-     * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command). Please also include a "cmdprefix" key & value pair if your command handler uses a prefix other than "!".
+     * @param context - The context (`this.`) of the object calling this command. Will be passed to respondModule() as first parameter to make working in this function easier.
+     * @param resInfo - Object containing additional information
      * @returns `true` if command was found, `false` if not
      */
-    runCommand(name: string, args: any[], steamID64: number, respondModule: (...params: any[]) => any, context: any, resInfo: any): boolean;
+    runCommand(name: string, args: any[], respondModule: (...params: any[]) => any, context: any, resInfo: resInfo): boolean;
     /**
      * Reloads all core commands. Does NOT reload commands registered at runtime. Please consider reloading the pluginSystem as well.
      */
     reloadCommands(): void;
 }
+
+/**
+ * @property [cmdprefix] - Prefix your command execution handler uses. This will be used in response messages referencing commands. Default: !
+ * @property userID - ID of the user who executed this command. Will be used for command default behavior (e.g. commenting on the requester's profile), to check for owner privileges, apply cooldowns and maybe your respondModule implementation for responding. Strongly advised to include.
+ * @property [ownerIDs] - Can be provided to overwrite `config.ownerid` for owner privilege checks. Useful if you are implementing a different platform and so `userID` won't be a steamID64 (e.g. discord)
+ * @property [charLimit] - Supported by the Steam Chat Message handler: Overwrites the default index from which response messages will be cut up into parts
+ * @property [cutChars] - Custom chars to search after for cutting string in parts to overwrite cutStringsIntelligently's default: [" ", "\n", "\r"]
+ * @property [fromSteamChat] - Set to true if your command handler is receiving messages from the Steam Chat and so `userID` can be expected to be a `steamID64`. Will be used to enable command default behavior (e.g. commenting on the requester's profile)
+ * @property [prefix] - Do not provide this argument, you'll receive it from commands: Steam Chat Message prefixes like /me. Can be ignored or translated to similar prefixes your platform might support
+ */
+declare type resInfo = {
+    cmdprefix?: string;
+    userID: string;
+    ownerIDs?: string[];
+    charLimit?: number;
+    cutChars?: string[];
+    fromSteamChat?: boolean;
+    prefix?: string;
+};
 
 /**
  * Internal: Do the actual commenting, activeRequests entry with all relevant information was processed by the comment command function above.
@@ -203,7 +234,7 @@ declare class CommandHandler {
  * @param commentArgs - All arguments this postComment function needs, without callback. It will be applied and a callback added as last param. Include a key called "quote" to dynamically replace it with a random quote.
  * @param receiverSteamID64 - steamID64 of the profile to receive the comments
  */
-declare function comment(commandHandler: CommandHandler, resInfo: any, respond: (...params: any[]) => any, postComment: (...params: any[]) => any, commentArgs: any, receiverSteamID64: string): void;
+declare function comment(commandHandler: CommandHandler, resInfo: CommandHandler.resInfo, respond: (...params: any[]) => any, postComment: (...params: any[]) => any, commentArgs: any, receiverSteamID64: string): void;
 
 /**
  * Retrieves arguments from a comment request. If request is invalid (for example too many comments requested) an error message will be sent
@@ -214,7 +245,7 @@ declare function comment(commandHandler: CommandHandler, resInfo: any, respond: 
  * @param respond - The shortened respondModule call
  * @returns Resolves promise with object containing all relevant data when done
  */
-declare function getCommentArgs(commandHandler: CommandHandler, args: any[], requesterSteamID64: string, resInfo: any, respond: (...params: any[]) => any): Promise<{ maxRequestAmount: number; commentcmdUsage: string; numberOfComments: number; profileID: string; idType: string; quotesArr: string[]; }>;
+declare function getCommentArgs(commandHandler: CommandHandler, args: any[], requesterSteamID64: string, resInfo: CommandHandler.resInfo, respond: (...params: any[]) => any): Promise<{ maxRequestAmount: number; commentcmdUsage: string; numberOfComments: number; profileID: string; idType: string; quotesArr: string[]; }>;
 
 /**
  * Finds all needed and currently available bot accounts for a comment request.
@@ -246,7 +277,7 @@ declare function getAvailableBotsForFavorizing(commandHandler: CommandHandler, a
  * @param respond - The shortened respondModule call
  * @returns If the user provided a specific amount, amount will be a number. If user provided "all" or "max", it will be returned as an unmodified string for getVoteBots.js to handle
  */
-declare function getSharedfileArgs(commandHandler: CommandHandler, args: any[], cmd: string, resInfo: any, respond: (...params: any[]) => any): Promise<{ amount: number | string; id: string; }>;
+declare function getSharedfileArgs(commandHandler: CommandHandler, args: any[], cmd: string, resInfo: CommandHandler.resInfo, respond: (...params: any[]) => any): Promise<{ amount: number | string; id: string; }>;
 
 /**
  * Finds all needed and currently available bot accounts for a vote request.
@@ -577,7 +608,7 @@ declare function checkConnection(url: string, throwTimeout: boolean): Promise<{ 
  * @param threshold - Optional: Maximum amount that limit can be reduced to find the last space or line break. If no match is found within this limit a word will be cut. Default: 15% of total length
  * @returns Returns all parts of the string in an array
  */
-declare function cutStringsIntelligently(txt: string, limit: number, cutChars: any[], threshold: number): any[];
+declare function cutStringsIntelligently(txt: string, limit: number, cutChars: string[], threshold: number): any[];
 
 /**
  * Attempts to reinstall all modules
@@ -1250,7 +1281,6 @@ declare class Updater {
      * Checks for any available update and installs it.
      * @param forceUpdate - If true an update will be forced, even if disableAutoUpdate is true or the newest version is already installed
      * @param respondModule - If defined, this function will be called with the result of the check. This allows to integrate checking for updates into commands or plugins. Passes resInfo and txt as parameters.
-     * @param resInfo - Object containing additional information your respondModule might need to process the response (for example the userID who executed the command).
      * @returns Promise that will be resolved with false when no update was found or with true when the update check or download was completed. Expect a restart when true was returned.
      */
     run(forceUpdate: boolean, respondModule: (...params: any[]) => any, resInfo: any): Promise<boolean>;


### PR DESCRIPTION
This PR removes the Command `steamID64` parameter and adds various properties to the `resInfo` object, which are documented in a new typedef.  
This solves a massive roadblock for integrating commands into other platforms via plugins.  

Plugins can now provide their own userIDs which enables the cooldown system and provide their own array of ownerIDs to make privilege checking possible.

Certain commands might block their default behavior for requests from outside Steam (for example !unfriend) and therefore require an ID parameter to be passed by the user.  
The usage of commands from the Steam Chat is not impacted by this change.